### PR TITLE
Allow node debugging

### DIFF
--- a/gulp/nodemon.js
+++ b/gulp/nodemon.js
@@ -16,6 +16,7 @@ gulp.task('server', function () {
   nodemon({
     script: 'server.js',
     ext: 'js, json',
+    nodeArgs: process.argv.slice(2),
     ignore: [config.paths.public + '*',
       config.paths.assets + '*',
       config.paths.nodeModules + '*']

--- a/start.js
+++ b/start.js
@@ -19,9 +19,14 @@ if (!envExists) {
 
 // Run gulp
 const spawn = require('cross-spawn')
+const argv = process.argv
 
 process.env['FORCE_COLOR'] = 1
-var gulp = spawn('gulp')
+const spawnArgs = ['gulp']
+if (argv.length > 2) {
+  spawnArgs.push(argv.splice(2))
+}
+var gulp = spawn(...spawnArgs)
 gulp.stdout.pipe(process.stdout)
 gulp.stderr.pipe(process.stderr)
 process.stdin.pipe(gulp.stdin)


### PR DESCRIPTION
Adds the ability to run the Node debugger by copying across the changes suggested in this issue and pull request on the prototype kit:
- issue: https://github.com/alphagov/govuk_prototype_kit/issues/495
- pull request: https://github.com/alphagov/govuk_prototype_kit/pull/497