### PR TITLE
Give preview generator its own content cache

### DIFF
--- a/app/assets/javascripts/modules/live-preview.js
+++ b/app/assets/javascripts/modules/live-preview.js
@@ -15,12 +15,12 @@
       function showPreview(evt) {
         var $el = $(this);
         var text = $(this).val() || '';
-        var previous = $(this).data('previous');
+        var previous = $(this).data('previous-preview-content');
 
         if (text == previous) {
           return;
         } else {
-          $(this).data('previous', text);
+          $(this).data('previous-preview-content', text);
         }
 
         $.ajax({


### PR DESCRIPTION
This code shared the same data attribute with the
content checker for checking if the content
entered had changed. If it had, the attribute was
set to the latest content.

This meant when the content checker looked at it
it saw no changes and didn't run any checks.

This change means each module uses it's own
attribute so they won't step on each other's toes.