### PR TITLE
Tidy up and document

### DIFF
--- a/lib/prototype-manager/add_taxons_to_items.js
+++ b/lib/prototype-manager/add_taxons_to_items.js
@@ -1,0 +1,36 @@
+const fs = require('fs');
+const path = require('path');
+const args = require('minimist')(process.argv.slice(2));
+
+const Queue = require('./govuk_api_queue');
+
+
+if (!('f' in args)) {
+  console.log('Please specify a file for the items');
+  process.exit();
+}
+
+const queue = new Queue({
+  'log': true
+});
+
+const itemFile = fs.readFileSync(path.resolve(__dirname, args.f));
+const items = JSON.parse(itemFile);
+
+items.forEach((item, idx) => {
+  queue.addRequest(item.base_path, function (jsonData) {
+    if ('taxons' in jsonData.links) {
+      jsonData.links.taxons.forEach(taxon => {
+        if (!('taxons' in item)) {
+          item.taxons = [];
+        }
+        item.taxons.push(taxon.base_path);
+      });
+    }
+  });
+});
+
+queue.on('done', function () {
+  fs.writeFileSync(path.resolve(__dirname, args.f), JSON.stringify(items, undefined, 2))
+});
+queue.start();

--- a/lib/prototype-manager/data_tables.js
+++ b/lib/prototype-manager/data_tables.js
@@ -55,10 +55,9 @@ function prerenderRows (items) {
       // summarise all time-series fields
       if (isTimeSeries(field, item[field])) {
 				let totalEntries = item[field].length;
-				let totalAmount = item[field].reduce((accumulator, currentEntry) => {
-          accumulator = (typeof accumulator === 'number') ? accumulator : parseInt(accumulator.value, 10);
-          return accumulator + parseInt(currentEntry.value, 10);
-        });
+				let totalAmount = item[field]
+                            .map(entry => parseInt(entry.value, 10))
+                            .reduce((accumulator, currentValue) => accumulator + currentValue);
 
 				// value is a summary of all entries in the time series
 				item[field] = totalAmount;

--- a/lib/prototype-manager/fake_collection_dates.js
+++ b/lib/prototype-manager/fake_collection_dates.js
@@ -1,0 +1,68 @@
+const path = require('path');
+const fs = require('fs');
+
+const csv = require('csv');
+const moment = require('moment');
+const args = require('minimist')(process.argv.slice(2));
+
+if (!('f' in args)) {
+  console.log('Provide a file to work on');
+}
+
+const jsonFile = fs.readFileSync(path.resolve(__dirname, args.f));
+const itemData = JSON.parse(jsonFile);
+const timeSeriesFields = [
+	'pageviews',
+	'unique_pageviews',
+	'number_of_internal_searches',
+	'is_this_useful_yes',
+	'is_this_useful_no',
+	'feedex_comments'
+];
+
+function getDaysToAdd (lastCollectionDate) {
+  const today = moment();
+  const diff = moment.duration(today.valueOf() - lastCollectionDate.valueOf());
+
+  return Math.floor(diff.asDays());
+};
+
+function updateDate (date, daystoAdd) {
+	let entryDate = moment(date);
+
+	entryDate.add(daysToAdd, 'days');
+
+	return entryDate.format('YYYY-MM-DD');
+};
+
+function getLastCollectionDate () {
+  const timeSeries = itemData[0][timeSeriesFields[0]];
+  let lastCollectionDate = null
+
+  timeSeries.forEach(entry => {
+    const entryDate = moment(entry.date);
+
+    if ((lastCollectionDate === null) || entryDate.isAfter(lastCollectionDate)) {
+      lastCollectionDate = entryDate;
+    }
+  });
+
+  return lastCollectionDate;
+}
+
+const lastCollectionDate = getLastCollectionDate();
+const daysToAdd = getDaysToAdd(lastCollectionDate);
+
+// update all entries
+itemData.forEach((item, idx) => {
+  for (let field in item) {
+    if (timeSeriesFields.includes(field)) {
+			item[field].forEach(entry => {
+				entry.date = updateDate(entry.date, daysToAdd);
+			});
+    }
+  }
+});
+
+fs.writeFileSync(path.resolve(__dirname, args.f), JSON.stringify(itemData, undefined, 2), { 'encoding': 'utf8' });
+console.log(`Date adjustments complete, results in ${args.f}`);

--- a/lib/prototype-manager/get_all_organisations.js
+++ b/lib/prototype-manager/get_all_organisations.js
@@ -1,0 +1,28 @@
+const https = require('https');
+
+https.request(
+	{
+		'host': 'www.gov.uk',
+		'path': '/api/content/government/organisations'
+	},
+	function (response) {
+		let str = '';
+
+		response.on('data', function (chunk) {
+			str += chunk;
+		});
+
+		response.on('end', function () {
+			const data = JSON.parse(str).details;
+      const orgs = [];
+
+      for (let key in data) {
+        data[key].forEach(entry => {
+          orgs.push({ 'title': entry.title, 'slug': entry.slug, 'acronym': entry.acronym });
+        });
+      }
+
+      process.stdout.write(JSON.stringify(orgs, undefined, 2));
+		});
+	}
+).end();

--- a/lib/prototype-manager/get_base_paths_for_taxons.js
+++ b/lib/prototype-manager/get_base_paths_for_taxons.js
@@ -1,0 +1,66 @@
+const fs = require('fs');
+const args = require('minimist')(process.argv.slice(2));
+
+const Queue = require('./govuk_api_queue');
+const taxonomy = require('./taxonomy');
+
+
+if (!('f' in args)) {
+  console.log('Please enter a file for the results');
+  process.exit();
+}
+
+const queue = new Queue({
+  'log': true,
+  'interval': 120
+});
+const levels = taxonomy.all.slice(0);
+let levelIdx = 0;
+
+function getTaxonRef (level, title) {
+  const idx = level.findIndex(taxon => taxon.name === title);
+  return level[idx];
+};
+
+function addBasePathsFromChildren (children, levelIdx) {
+  children.forEach(taxon => {
+    const taxonRef = getTaxonRef(levels[levelIdx], taxon.title);
+
+    taxonRef.basePath = taxon.base_path;
+  });
+};
+
+let count = 0;
+
+function processNode (node, levelIdx) {
+  let childTaxons;
+
+  if ('level_one_taxons' in node.links) {
+    childTaxons = node.links.level_one_taxons;
+  }
+  if ('child_taxons' in node.links) {
+    childTaxons = node.links.child_taxons;
+  }
+
+  if (childTaxons) {
+    levelIdx = levelIdx + 1;
+    addBasePathsFromChildren(childTaxons, levelIdx);
+    childTaxons.forEach(taxon => {
+      queue.addRequest(taxon.base_path, function (jsonData) {
+        processNode(jsonData, levelIdx);
+      });
+    });
+
+    return true;
+  }
+
+  return false;
+};
+
+queue.addRequest('/', function (jsonData) {
+  processNode(jsonData, levelIdx);
+});
+queue.onDone = function () {
+  fs.writeFileSync(args.f, JSON.stringify(levels, undefined, 2));
+};
+queue.start();

--- a/lib/prototype-manager/govuk_api_queue.js
+++ b/lib/prototype-manager/govuk_api_queue.js
@@ -1,0 +1,104 @@
+const fs = require('fs');
+const path = require('path');
+const fetch = require('node-fetch');
+
+
+class RequestQueue {
+  constructor (opts) {
+    this._queue = [];
+    this._opts = opts || {
+      'log': false
+    };
+  }
+
+  get interval () {
+    return this._opts.interval || 105;
+  }
+
+  get isDone () {
+    return this._queue.length === 0;
+  }
+
+  log (message) {
+    if (this._opts.log) {
+      console.log(message);
+    }
+  }
+
+  makeResponseHandler (basePath, callback) {
+    const self = this;
+
+    return function (jsonData) {
+      // remove item just requested
+      self._queue.pop();
+
+      callback(jsonData);
+    }
+  };
+
+  makeErrorHandler (basePath) {
+    return function (err) {
+      throw new Error(`Request for ${basePath} failed with: ${err.message}`);
+    };
+  };
+
+  addRequest (basePath, callback) {
+    const self = this;
+
+    function request () {
+      const url = `https://www.gov.uk/api/content${basePath}`;
+      let responseHandler = self.makeResponseHandler(basePath, callback);
+      let errorHandler = self.makeErrorHandler(basePath);
+
+      self.log(`Calling: ${url}`);
+
+      fetch(url)
+        .then(res => {
+          if (res.status !== 200) {
+            throw new Error(`Request to ${url} returned ${res.status}`);
+          }
+          return res.json();
+        })
+        .then(json => {
+          responseHandler(json);
+        })
+        .then(() => {
+          if (!self.isDone) {
+            self.next();
+          }
+          else {
+            self.onDone();
+          }
+        })
+        .catch(errorHandler);
+    };
+
+    this._queue.push(request);
+  }
+
+  start () {
+    this._queue[0]();
+  }
+
+  next () {
+    const queue = this._queue;
+    const lastItem = queue.length - 1;
+
+    function request () {
+      queue[lastItem]();
+    };
+
+    setTimeout(request, this.interval);
+  } 
+
+  // stub function if onDone not set
+  onDone () {}
+
+  on (evt, callback) {
+    if (evt === 'done') {
+      this.onDone = callback;
+    }
+  }
+};
+
+module.exports = RequestQueue;


### PR DESCRIPTION
Some tidying and scripts for the content manager part of the prototype.

### Tidying

The tidying is for the `data_tables` code that handles the data in the main dashboard tables.

### Scripts

The scripts came from the need to transform CSV dumps (from the data warehouse) into something the `data_tables` code can use.

They are:

| Script | Description |
|--------|-------------|
| `add_taxons_to_items.js` | Gets the base paths of all taxons for each content item in a dataset. Will add them to the JSON file given |
| `govuk_api_queue.js` | Module to queue up requests to the GOV.UK API without hitting the rate limit |
| `get_base_paths_for_taxons.js` | Gets the full taxonomy tree from the GOV.UK API so it can be added to `taxonomy.js` |
| `get_all_organisations.js` | Gets a list of all organisations from the GOV.UK API |
